### PR TITLE
Allowing system vars in dotenv

### DIFF
--- a/src/issues/api.js
+++ b/src/issues/api.js
@@ -3,8 +3,6 @@
 import useSWR from 'swr'
 import PouchDB from 'pouchdb'
 
-console.log(process.env)
-
 const DATABASE_URL = process.env.DATABASE_URL
 
 const db = new PouchDB(`${DATABASE_URL}/issues`)
@@ -28,7 +26,7 @@ export const useIssuesDB = () => {
   )
 
   return {
-    create: newIssue => db.post(newIssue).then(() => mutate(issues)),
+    create: (newIssue) => db.post(newIssue).then(() => mutate(issues)),
     getInfo: db.info,
     issues,
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = {
     ],
   },
   plugins: [
-    new Dotenv({ safe: true }),
+    new Dotenv({ safe: true, systemvars: true }),
     new HtmlWebPackPlugin({
       template: './src/index.html',
       filename: './index.html',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,6 @@
 const HtmlWebPackPlugin = require('html-webpack-plugin')
 const Dotenv = require('dotenv-webpack')
 
-console.log(process.env)
-
 module.exports = {
   mode: 'development',
   entry: './src/index.js',


### PR DESCRIPTION
Webpack was able to access `process.env` variables in, but wasn't passing them to the built code (see image). Allowing system vars in the webpack-dotenv call fixed this.

See: https://www.npmjs.com/package/dotenv-webpack#properties

<img width="1366" alt="Screen Shot 2020-12-29 at 11 00 16 PM" src="https://user-images.githubusercontent.com/145783/103389844-7dd8a300-4ace-11eb-8060-ba8a38e9b509.png">

